### PR TITLE
feat: update post GET APIs to include comment and like counts/details

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,14 +122,14 @@ model activity_comments {
 }
 
 model post_comments {
-  comment_id      Int                  @id @default(autoincrement())
+  comment_id      Int                          @id @default(autoincrement())
   post_id         Int
-  comment_content String               @db.Text
-  uid             String               @db.VarChar(255)
-  created_at      DateTime             @default(now()) @db.DateTime(0)
-  status          post_comments_status
-  users           users                @relation(fields: [uid], references: [uid], onDelete: NoAction, onUpdate: NoAction, map: "FK_postComments_users")
-  posts           posts                @relation(fields: [post_id], references: [post_id], onDelete: NoAction, map: "FK_postComments_users-postid")
+  comment_content String                       @db.Text
+  uid             String                       @db.VarChar(255)
+  created_at      DateTime                     @default(now()) @db.DateTime(0)
+  comment_status  post_comments_comment_status
+  users           users                        @relation(fields: [uid], references: [uid], onDelete: NoAction, onUpdate: NoAction, map: "FK_postComments_users")
+  posts           posts                        @relation(fields: [post_id], references: [post_id], onDelete: NoAction, map: "FK_postComments_users-postid")
 
   @@index([post_id], map: "FK_postComments_users-postid_idx")
   @@index([uid], map: "FK_postComments_users_idx")
@@ -146,17 +146,21 @@ model posts {
   post_status   posts_post_status
   post_img      String?             @db.Text
   post_comments post_comments[]
+  post_likes    post_likes[]
   users         users               @relation(fields: [uid], references: [uid], map: "FK_posts_users-uid")
 
   @@index([uid], map: "FK_posts_users-uid_idx")
 }
 
 model post_likes {
-  like_id    Int               @id @default(autoincrement())
-  post_id    Int
-  uid        String            @db.VarChar(255)
-  created_at DateTime?         @default(now()) @db.Timestamp(0)
-  status     post_likes_status
+  like_id     Int                    @id @default(autoincrement())
+  post_id     Int
+  uid         String                 @db.VarChar(255)
+  created_at  DateTime?              @default(now()) @db.Timestamp(0)
+  like_status post_likes_like_status
+  posts       posts                  @relation(fields: [post_id], references: [post_id], onDelete: Cascade, map: "fk_post_likes_posts")
+
+  @@index([post_id], map: "fk_post_likes_posts")
 }
 
 model notifications {
@@ -226,11 +230,6 @@ enum posts_post_category {
   others
 }
 
-enum post_comments_status {
-  active
-  deleted
-}
-
 enum notifications_action {
   like
   comment
@@ -245,7 +244,12 @@ enum notifications_target_type {
   rating
 }
 
-enum post_likes_status {
+enum post_likes_like_status {
   liked
   unlike
+}
+
+enum post_comments_comment_status {
+  active
+  deleted
 }

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -1,6 +1,6 @@
 import { postService } from "../services/postService.js";
 
-const fetchAllPosts = async (req, res, next) => {
+const fetchAllPosts = async (_req, res, next) => {
   try {
     const response = await postService.getAllPosts();
     if (!response) {
@@ -105,7 +105,9 @@ const removePost = async (req, res, next) => {
       message: "資料刪除成功",
       data: response,
     });
-  } catch (error) {}
+  } catch (error) {
+    next(error);
+  }
 };
 
 const fetchPostComments = async (req, res, next) => {

--- a/src/routes/postRoutes.js
+++ b/src/routes/postRoutes.js
@@ -24,7 +24,3 @@ router.post("/like/:post_id", PostController.addPostLike);
 router.delete("/like/:like_id", PostController.removePostLike);
 
 export default router;
-
-// all post likes and comments count
-// post all info and likes and comments
-// category post likes and comments count

--- a/src/services/postService.js
+++ b/src/services/postService.js
@@ -9,7 +9,7 @@ import {
 } from "../validations/postSchema.js";
 
 export const postService = {
-  // 獲得所有 post
+  // 獲得所有 posts (包含留言與按讚數量)
   async getAllPosts() {
     const response = await prisma.posts.findMany({
       // 過濾文章狀態 "posted"
@@ -48,7 +48,7 @@ export const postService = {
     }));
   },
 
-  // 獲得單一 post
+  // 獲得單一 post (包含留言與按讚詳細資料)
   async getPost(post_id) {
     GetPostSchema.parse({ post_id });
     return await prisma.posts.findUnique({
@@ -89,7 +89,7 @@ export const postService = {
     });
   },
 
-  // 根據分類獲得 posts
+  // 根據分類獲得 posts (包含留言與按讚數量)
   async getPostByCategory(post_category) {
     GetCategoryPostSchema.parse({ post_category });
     const response = await prisma.posts.findMany({
@@ -241,7 +241,7 @@ export const postService = {
           data: { status: "unlike" },
         });
       }
-      return existingLike; // 已經是 "unlike"，直接返回
+      return existingLike;
     } else {
       throw new Error("記錄不存在，無法取消按讚");
     }


### PR DESCRIPTION
### 變更內容：
1. GET /posts：獲取所有文章時，返回的數據包含留言數與讚數。
2. GET /posts/category/:category：依分類獲取文章時，返回的數據包含留言數與讚數。
3. GET /posts/:post_id：獲取單篇文章時，返回詳細的留言資訊和按讚資訊。

### 背景信息：
1. 為了提升前端顯示文章的完整度，這些改動將直接返回需要的留言數和讚數。
2. 依分類和單篇文章的 API 返回更詳細的信息，避免多次請求造成性能影響。

### 測試方法：
手動測試所有 API，確認數據結構是否正確：
   - GET /posts：
      - 確認每篇文章包含 comments_count 和 likes_count。
   - GET /posts/category/:category：
      - 確認返回的文章屬於指定分類，並包含 comments_count 和 likes_count。
   - GET /posts/:post_id：
      - 確認返回的文章詳細數據中，包含完整的留言列表與按讚用戶列表。

### 影響範圍
修改了 postService 中的 getAllPosts、getPostsByCategory、getPost。

### 檢查清單
- 已更新後端 API 代碼，確保返回數據包含留言數與讚數。
- 已執行並通過本地測試，檢查 API 返回結果的正確性。

#2 