### PR TITLE
feat: update post APIs with user info, popular posts, and latest posts endpoints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,6 @@ model activities {
   users             users               @relation(fields: [host_id], references: [uid], onUpdate: Restrict, map: "12")
   activity_comments activity_comments[]
   applications      applications[]
-  ratings           ratings[]
 
   @@index([host_id], map: "host_idanduid_idx")
 }
@@ -52,8 +51,8 @@ model users {
   hobby                                       String?             @db.VarChar(45)
   expertise                                   String?             @db.VarChar(45)
   interested_in                               String?             @db.VarChar(255)
-  life_photo_1                                String?             @default("https://firebasestorage.googleapis.com/v0/b/login-demo1-9d3cb.firebasestorage.app/o/lifephoto%2F1733574359943_defaultimg.jpg?alt=media&token=c5486472-dadd-4276-8666-97a538e46e5f") @db.VarChar(2000)
-  life_photo_2                                String?             @default("https://firebasestorage.googleapis.com/v0/b/login-demo1-9d3cb.firebasestorage.app/o/lifephoto%2F1733574359943_defaultimg.jpg?alt=media&token=c5486472-dadd-4276-8666-97a538e46e5f") @db.VarChar(2000)
+  life_photo_1                                String?             @db.Text
+  life_photo_2                                String?             @db.Text
   activities                                  activities[]
   activity_comments                           activity_comments[]
   applications                                applications[]
@@ -92,23 +91,20 @@ model followers {
 }
 
 model ratings {
-  rating_id                    Int        @id @unique(map: "rating_id_UNIQUE") @default(autoincrement())
-  user_id                      String     @db.VarChar(255)
-  host_id                      String     @db.VarChar(255)
+  rating_id                    Int      @id @unique(map: "rating_id_UNIQUE") @default(autoincrement())
+  user_id                      String   @db.VarChar(255)
+  host_id                      String   @db.VarChar(255)
   rating_heart                 Int
-  user_comment                 String     @db.Text
+  user_comment                 String   @db.Text
   rating_kindness              Int
   rating_ability               Int
   rating_credit                Int
-  created_at                   DateTime   @default(now()) @db.DateTime(0)
-  activity_id                  Int
-  activities                   activities @relation(fields: [activity_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "bind activity id")
-  users_ratings_host_idTousers users      @relation("ratings_host_idTousers", fields: [host_id], references: [uid], onDelete: NoAction, onUpdate: NoAction, map: "bind host id")
-  users_ratings_user_idTousers users      @relation("ratings_user_idTousers", fields: [user_id], references: [uid], onDelete: Cascade, map: "bind user id")
+  created_at                   DateTime @default(now()) @db.DateTime(0)
+  users_ratings_host_idTousers users    @relation("ratings_host_idTousers", fields: [host_id], references: [uid], onDelete: NoAction, onUpdate: NoAction, map: "bind host id")
+  users_ratings_user_idTousers users    @relation("ratings_user_idTousers", fields: [user_id], references: [uid], onDelete: Cascade, map: "bind user id")
 
   @@index([host_id], map: "bind host id_idx")
   @@index([user_id], map: "bind id_idx")
-  @@index([activity_id], map: "bind activity id_idx")
 }
 
 model activity_comments {
@@ -126,13 +122,14 @@ model activity_comments {
 }
 
 model post_comments {
-  comment_id      Int      @id @default(autoincrement())
+  comment_id      Int                          @id @default(autoincrement())
   post_id         Int
-  comment_content String   @db.Text
-  uid             String   @db.VarChar(255)
-  created_at      DateTime @default(now()) @db.DateTime(0)
-  users           users    @relation(fields: [uid], references: [uid], onDelete: NoAction, onUpdate: NoAction, map: "FK_postComments_users")
-  posts           posts    @relation(fields: [post_id], references: [post_id], onDelete: NoAction, map: "FK_postComments_users-postid")
+  comment_content String                       @db.Text
+  uid             String                       @db.VarChar(255)
+  created_at      DateTime                     @default(now()) @db.DateTime(0)
+  comment_status  post_comments_comment_status
+  users           users                        @relation(fields: [uid], references: [uid], onDelete: NoAction, onUpdate: NoAction, map: "FK_postComments_users")
+  posts           posts                        @relation(fields: [post_id], references: [post_id], onDelete: NoAction, map: "FK_postComments_users-postid")
 
   @@index([post_id], map: "FK_postComments_users-postid_idx")
   @@index([uid], map: "FK_postComments_users_idx")
@@ -149,17 +146,21 @@ model posts {
   post_status   posts_post_status
   post_img      String?             @db.Text
   post_comments post_comments[]
+  post_likes    post_likes[]
   users         users               @relation(fields: [uid], references: [uid], map: "FK_posts_users-uid")
 
   @@index([uid], map: "FK_posts_users-uid_idx")
 }
 
 model post_likes {
-  like_id    Int       @id @default(autoincrement())
-  post_id    Int
-  comment_id Int
-  uid        String    @db.VarChar(255)
-  created_at DateTime? @default(now()) @db.DateTime(0)
+  like_id     Int                    @id @default(autoincrement())
+  post_id     Int
+  uid         String                 @db.VarChar(255)
+  created_at  DateTime?              @default(now()) @db.Timestamp(0)
+  like_status post_likes_like_status
+  posts       posts                  @relation(fields: [post_id], references: [post_id], onDelete: Cascade, map: "fk_post_likes_posts")
+
+  @@index([post_id], map: "fk_post_likes_posts")
 }
 
 model notifications {
@@ -241,4 +242,14 @@ enum notifications_target_type {
   post
   activity
   rating
+}
+
+enum post_likes_like_status {
+  liked
+  unlike
+}
+
+enum post_comments_comment_status {
+  active
+  deleted
 }

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -22,6 +22,44 @@ const fetchAllPosts = async (req, res, next) => {
   }
 };
 
+const fetchLeastPosts = async (_req, res, next) => {
+  try {
+    const response = await postService.getLeastPosts();
+    if (!response) {
+      return res.status(404).json({
+        status: 404,
+        message: "查無資料",
+      });
+    }
+    res.status(200).json({
+      status: 200,
+      message: "資料獲取成功",
+      data: response,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const fetchPopularPosts = async (_req, res, next) => {
+  try {
+    const response = await postService.getPopularPosts();
+    if (!response) {
+      return res.status(404).json({
+        status: 404,
+        message: "查無資料",
+      });
+    }
+    res.status(200).json({
+      status: 200,
+      message: "資料獲取成功",
+      data: response,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 const fetchPostDetails = async (req, res, next) => {
   try {
     const post_id = parseInt(req.params.post_id);
@@ -218,6 +256,8 @@ const removePostLike = async (req, res, next) => {
 
 export {
   fetchAllPosts,
+  fetchLeastPosts,
+  fetchPopularPosts,
   fetchPostDetails,
   fetchPostsByCategory,
   addPost,

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -1,8 +1,11 @@
 import { postService } from "../services/postService.js";
 
-const fetchAllPosts = async (_req, res, next) => {
+const fetchAllPosts = async (req, res, next) => {
   try {
-    const response = await postService.getAllPosts();
+    const page = parseInt(req.query.page, 10) || 1;
+    const pageSize = parseInt(req.query.pageSize, 10) || 15;
+
+    const response = await postService.getAllPosts(page, pageSize);
     if (!response) {
       return res.status(404).json({
         status: 404,

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -22,7 +22,7 @@ const fetchAllPosts = async (req, res, next) => {
   }
 };
 
-const fetchLeastPosts = async (_req, res, next) => {
+const fetchLatestPosts = async (_req, res, next) => {
   try {
     const response = await postService.getLeastPosts();
     if (!response) {
@@ -256,7 +256,7 @@ const removePostLike = async (req, res, next) => {
 
 export {
   fetchAllPosts,
-  fetchLeastPosts,
+  fetchLatestPosts,
   fetchPopularPosts,
   fetchPostDetails,
   fetchPostsByCategory,

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -24,7 +24,7 @@ const fetchAllPosts = async (req, res, next) => {
 
 const fetchLatestPosts = async (_req, res, next) => {
   try {
-    const response = await postService.getLeastPosts();
+    const response = await postService.getLatestPosts();
     if (!response) {
       return res.status(404).json({
         status: 404,

--- a/src/routes/postRoutes.js
+++ b/src/routes/postRoutes.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 // Post List
 router.get("/", PostController.fetchAllPosts);
-router.get("/least", PostController.fetchLeastPosts);
+router.get("/latest", PostController.fetchLatestPosts);
 router.get("/popular", PostController.fetchPopularPosts);
 router.get("/:post_id", PostController.fetchPostDetails);
 router.get("/category/:category", PostController.fetchPostsByCategory);

--- a/src/routes/postRoutes.js
+++ b/src/routes/postRoutes.js
@@ -5,6 +5,8 @@ const router = express.Router();
 
 // Post List
 router.get("/", PostController.fetchAllPosts);
+router.get("/least", PostController.fetchLeastPosts);
+router.get("/popular", PostController.fetchPopularPosts);
 router.get("/:post_id", PostController.fetchPostDetails);
 router.get("/category/:category", PostController.fetchPostsByCategory);
 

--- a/src/services/postService.js
+++ b/src/services/postService.js
@@ -56,7 +56,7 @@ export const postService = {
   },
 
   // 獲得最新貼文（十五篇）
-  async getLeastPosts() {
+  async getLatestPosts() {
     const response = await prisma.posts.findMany({
       where: {
         post_status: "posted",

--- a/src/services/postService.js
+++ b/src/services/postService.js
@@ -84,6 +84,10 @@ export const postService = {
       take: 15,
     });
 
+    if (!response || response.length === 0) {
+      return null;
+    }
+
     const formattedResponse = {
       data: response.map((post) => ({
         ...post,


### PR DESCRIPTION
### 變更內容
1. 更新 GET /posts API：
   - 返回的數據新增包含 display_name（使用者名稱） 和 photo_url（使用者頭像）。
   - 取消分頁功能，拆分為獲取最新文章和熱門文章的 API。
2. 新增 GET /posts/popular API：
   - 提供 15 天 內的熱門貼文，依據按讚數進行排序返回。
3. 新增 GET /posts/latest API：
   - 返回最新 15 篇文章 的資訊。
   
### 背景信息
1. 提升數據完整性：
   - 在文章列表中顯示使用者名稱與頭像，讓前端顯示更加豐富完整。
2. 實現分頁邏輯的替代方案：
   - 減少 API 單次返回數據量，分拆獲取最新和熱門文章，提升效能。
3. 新增熱門貼文功能：
   - 方便前端呈現依據按讚數排序的熱門內容。

### 測試方法

**手動測試步驟**
1. GET /posts：
- 確認 API 返回每篇文章的 display_name 和 photo_url 欄位。
2. GET /posts/popular：
- 確認 API 正確返回 15 天內的熱門貼文，並依照按讚數進行排序。
3. GET /posts/latest：
- 確認 API 返回最新 15 篇文章。

### 影響範圍

**模塊**
- postService.js
- postRouter.js
- postController.js

**受影響方法**
- getAllPosts：新增 display_name 和 photo_url 欄位，取消分頁功能。

**新增方法**
- getPopularPosts：返回 15 天內依據按讚數排序的熱門貼文。
- getLatestPosts：返回最新 15 篇文章。

關聯 Issue
#6 
