### PR TITLE
feat: add search activity api

### DIFF
--- a/src/controllers/activityController.js
+++ b/src/controllers/activityController.js
@@ -132,6 +132,50 @@ const removeActivityComment = async (req, res, next) => {
   }
 };
 
+const searchActivities = async (req, res, next) => {
+  try{
+    let { keyword } = req.body
+    switch (keyword) {
+      case '運動':
+        keyword = 'sport' 
+        break;
+      case '美食':
+        keyword = 'food'
+        break;
+      case '旅遊':
+        keyword = 'travel' 
+        break;
+      case '購物':
+        keyword = 'shopping'
+        break
+      case '教育':
+        keyword = 'education'
+        break
+      default:
+        break;
+
+    }
+
+    const response = await activityService.searchActivities(keyword)
+
+    if(response.length === 0){
+      return res.status(404).json({
+        message: "查無此資料",
+        status: 404,
+        data: [],
+      })
+    }
+    res.status(200).json({
+      message: "資料獲取成功",
+      status: 200,
+      data: response,
+    })
+    // prism找資料
+  } catch (error) {
+    next(error)
+  }
+}
+
 export {
   fetchAllActiveActivities,
   fetchActivityDetails,
@@ -140,4 +184,5 @@ export {
   cancelActivityRequest,
   fetchActivityComments,
   removeActivityComment,
+  searchActivities,
 };

--- a/src/routes/activityRoutes.js
+++ b/src/routes/activityRoutes.js
@@ -11,6 +11,7 @@ router.get("/category/:category", ActivityController.fetchActivitiesByCategory);
 // Activity Create/Delete
 router.post("/", ActivityController.addNewActivity);
 router.put("/cancel/:id", ActivityController.cancelActivityRequest);
+router.post("/search", ActivityController.searchActivities);
 
 // Activity Comment
 router.post("/comment/:activity_id", ActivityController.fetchActivityComments);

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -269,5 +269,37 @@ export const activityService = {
       validated_registrations: _count.applications
     }
   },
+
+  async searchActivities(keyword){
+    return await prisma.activities.findMany({
+      where: {
+        status: "registrationOpen",
+        //今天以後的活動
+        event_time: {
+          gte: new Date(),
+        },
+        OR: [
+          {
+            name: {
+              contains: keyword,
+            },
+          },
+          {
+            description: {
+              contains: keyword,
+            },
+          },
+          {
+            location: {
+              contains: keyword,
+            },
+          },
+        ],
+      },
+      orderBy: {
+        event_time: "asc",
+      }
+    })
+  }
 };
 


### PR DESCRIPTION
**新增 /activities/search 關鍵字搜尋 API**

本次 PR 實現了一個新的 API，提供以關鍵字搜尋活動的功能。

實現功能
API 路徑：/activities/search

請求方式：

接受 POST 請求，body 中需要包含 keyword 參數。

支援以下關鍵字（中英文對應）：
- 運動 → sport
- 美食 → food
- 旅遊 → travel
- 購物 → shopping
- 教育 → education

若關鍵字未匹配，則使用原始的關鍵字進行搜尋。
回應內容：

- 返回符合關鍵字的活動清單，搜尋範圍包括活動的 name、description 和 location 欄位。
- 僅篩選 status: "registrationOpen" 且 event_time >= 今日 的活動。
- 搜尋結果依照 event_time 升序排序。
- 若無符合條件的結果，返回 404 狀態碼及提示訊息。