### PR TITLE
feat: add one to many notification for creating activity or post

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -347,6 +347,8 @@ enum notifications_action {
   register
   review
   rate
+  create
+  follow
 }
 
 enum notifications_target_type {

--- a/src/config/socket.js
+++ b/src/config/socket.js
@@ -1,5 +1,5 @@
-import { Server } from "socket.io"
-import { userService } from "../services/userService.js"
+import { Server } from "socket.io";
+import { userService } from "../services/userService.js";
 import "dotenv/config";
 
 export const initSocket = (server) => {
@@ -7,29 +7,30 @@ export const initSocket = (server) => {
     cors: {
       origin: process.env.FRONTEND_URL, // 前端地址
       methods: ["GET", "POST"],
-      credentials: true
-    }
-  })
-  
-  
-  io.on('connection', (socket) => {
-    // 聽到authenticate就開這個通道
-    socket.on('authenticate', (userId) => {
-      console.log(userId)
-      socket.join(userId)
-    })
-    // 聽到sendNotification時就根據挾帶的data裡面是否有帶要給這個資訊人的id，把data打到那個通道
-    socket.on('sendNotification', async (data) => {
-      //拿到提醒先新增在資料庫
-      const response = await userService.addNotification(data)
-      // 成功新增資料庫之後將提醒直接發給該使用者
-      console.log(response)
-      // io.to(data.receiverId).emit('newNotification', data);
-      if(!response){
-        return
-      }
-      io.to(data.user_id).emit('newNotification', response)
+      credentials: true,
+    },
+  });
 
+  io.on("connection", (socket) => {
+    // 聽到authenticate就開這個通道
+    socket.on("authenticate", (userId) => {
+      socket.join(userId);
     });
-  })
-}
+    // 聽到sendNotification時就根據挾帶的data裡面是否有帶要給這個資訊人的id，把data打到那個通道
+    socket.on("sendNotification", async (data) => {
+      if (data.action == "create") {
+        // data 0 為通知內容 1 為使用者陣列
+        const data = await userService.addNotifications(data);
+        io.to(data[1]).emit("newNotification", data[0]);
+      } else {
+        //拿到提醒先新增在資料庫
+        const response = await userService.addNotification(data);
+        // 成功新增資料庫之後將提醒直接發給該使用者
+        if (!response) {
+          return;
+        }
+        io.to(data.user_id).emit("newNotification", response);
+      }
+    });
+  });
+};

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -168,9 +168,32 @@ export const activityService = {
       approval_deadline: convertToISOString(activityData.approval_deadline),
       event_time: convertToISOString(activityData.event_time),
     };
-    return await prisma.activities.create({
+
+    const activity = await prisma.activities.create({
       data: formattedActivityData,
     });
+
+    //通知訂閱者
+    const followers = await userService.getSimplifyFollowers(activity.host_id);
+    if (followers.length == 0) {
+      return;
+    }
+    const data = followers.map((follower) => {
+      return {
+        actor_id: activity.host_id,
+        user_id: follower.follower_id,
+        action: "create",
+        target_type: "activity",
+        target_id: activity.id,
+        message: "剛建立了一個活動！",
+        link: `/activity/detail/${activity.id}`,
+      };
+    });
+    await prisma.notifications.createMany({
+      data,
+    });
+
+    return activity;
   },
 
   // 免審核的活動報名

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -147,6 +147,82 @@ export const userService = {
     }
   },
 
+  async addNotifications(data) {
+    try {
+      // 先校驗
+      NotificationSchema.parse(data);
+      const { actor_id, action, target_type, target_id, message, link } = data;
+      const followers = await userService.getSimplifyFollowers(actor_id);
+      if (followers.length == 0) return;
+
+      const followersArray = followers.map((follower) => {
+        return {
+          actor_id,
+          user_id: follower.follower_id,
+          action,
+          target_type,
+          target_id,
+          message,
+          link,
+        };
+      });
+
+      await prisma.notifications.createMany({
+        data: followersArray,
+      });
+
+      const detailResponse = await prisma.notifications.findFirst({
+        where: { actor_id, action, target_id },
+        select: {
+          users_notifications_actor_idTousers: {
+            select: {
+              display_name: true,
+              photo_url: true,
+            },
+          },
+          message: true,
+          action: true,
+          is_read: true,
+          created_at: true,
+          target_type: true,
+          target_id: true,
+          id: true,
+          link: true,
+        },
+      });
+      let target_detail;
+      switch (detailResponse.target_type) {
+        case "activity":
+          target_detail = await prisma.activities.findUnique({
+            where: { id: detailResponse.target_id },
+            select: {
+              name: true,
+            },
+          });
+          break;
+        case "post":
+          target_detail = await prisma.posts.findUnique({
+            where: { post_id: detailResponse.target_id },
+            select: {
+              post_title: true,
+            },
+          });
+          break;
+      }
+      const followerIds = followers.map((data) => data.follower_id);
+      return [
+        {
+          ...detailResponse,
+          target_detail,
+        },
+        followerIds,
+      ];
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
+  },
+
   async getUserNotifications(uid, page, pageSize, additionalSkip) {
     const skip = (page - 1) * pageSize + additionalSkip;
     const response = await prisma.notifications.findMany({
@@ -320,6 +396,18 @@ export const userService = {
       },
       data: {
         isFollowing: false,
+      },
+    });
+  },
+
+  async getSimplifyFollowers(user_id) {
+    return await prisma.followers.findMany({
+      where: {
+        user_id,
+        isFollowing: true,
+      },
+      select: {
+        follower_id: true,
       },
     });
   },

--- a/src/validations/userSchema.js
+++ b/src/validations/userSchema.js
@@ -53,7 +53,15 @@ export const GetFollowingSchema = z.object({
 export const NotificationSchema = z.object({
   user_id: z.string().max(255),
   actor_id: z.string().max(255),
-  action: z.enum(["like", "comment", "register", "review", "rate"]),
+  action: z.enum([
+    "like",
+    "comment",
+    "register",
+    "review",
+    "rate",
+    "create",
+    "follow",
+  ]),
   target_type: z.enum(["post", "activity", "rating"]),
   message: z.string(),
 });
@@ -61,7 +69,6 @@ export const NotificationSchema = z.object({
 export const NotificationListSchema = z.object({
   unreadList: z.array(z.number().int()).min(1),
 });
-
 
 export const CreateRatingSchema = z.object({
   host_id: z.string().max(255),
@@ -71,4 +78,4 @@ export const CreateRatingSchema = z.object({
   rating_kindness: z.number().int().min(1).max(5),
   rating_ability: z.number().int().min(1).max(5),
   rating_credit: z.number().int().min(1).max(5),
-})
+});


### PR DESCRIPTION
- socket先判斷是一對多還是一對一的情況，去觸發不同function (addNotification/addNotifications)
- addNotifications處理一對多的情況 (目前僅有 action 為 create的行為會被歸類為一對多，其他都為一對一)

步驟 
1. 先抓到所有的followers，並整理成可以儲存的格式
2. 加到notifications
3. 取得完整的提醒資料 (前端可以顯示的狀態)
4. 統一發送